### PR TITLE
Creating a merge queue

### DIFF
--- a/.github/workflows/merge_queue.yaml
+++ b/.github/workflows/merge_queue.yaml
@@ -1,0 +1,18 @@
+name: Validate code in the merge queue
+
+on:
+  merge_group:
+
+jobs:
+  validate-pr:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Display info
+      run: | 
+        pwd
+        tree -a -I '.git'
+        git status
+    - name: Run slow CI (emulated by a long sleep)
+      run: sleep 300

--- a/.github/workflows/validate_pr.yaml
+++ b/.github/workflows/validate_pr.yaml
@@ -1,0 +1,18 @@
+name: Validate pull request before putting into queue
+
+on:
+  pull_request:
+
+jobs:
+  validate-pr:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+    - name: Display info
+      run: | 
+        pwd
+        tree -a -I '.git'
+        git status
+    - name: Run fast CI (emulated by a short sleep)
+      run: sleep 5


### PR DESCRIPTION
This pull request introduces two new GitHub Actions workflows to validate code in different stages of the development process. One workflow validates code when a pull request is created, and the other validates code in the merge queue.

New GitHub Actions workflows:

* [`.github/workflows/validate_pr.yaml`](diffhunk://#diff-01ea11b6884aa597e73290170a4ef1919fe594ba213f59ee8f73c1f188166e1cR1-R18): Adds a workflow to validate pull requests before they are put into the merge queue. This includes checking out the code, displaying information, and running a fast CI process.
* [`.github/workflows/merge_queue.yaml`](diffhunk://#diff-ca62102b21986d8d0698220a938ade3c0a51bb5fb6e81ad906858141a5044f97R1-R18): Adds a workflow to validate code in the merge queue. This includes checking out the code, displaying information, and running a slow CI process.